### PR TITLE
Fix a problem where findFallbackAsync will always fail

### DIFF
--- a/postbin/__init__.py
+++ b/postbin/__init__.py
@@ -82,7 +82,7 @@ async def findFallBackAsync(verbose: bool = True):
             if verbose:
                 print(f"Trying service {n}/{len(_FALLBACKS)}",end="\r")
             try:
-                async with session.post(url, data="") as response:
+                async with session.post(url+"/documents", data="") as response:
                     if response.status != 200:
                         continue
                     else:

--- a/postbin/__init__.py
+++ b/postbin/__init__.py
@@ -20,7 +20,8 @@ import asyncio
 _FALLBACKS = [
     "https://hastebin.com",
     "https://paste.pythondiscord.com",
-    "https://haste.unbelievaboat.com"
+    "https://haste.unbelievaboat.com",
+    "https://mystb.in"
 ]
 _HASTE_URLS_FOR_REGEX = '|'.join(_FALLBACKS[8:]).replace(".", "\\.")
 _HASTE_URLS_RAW = "(https://|http://)?({})/(raw/)?(?P<key>.+)".format(_HASTE_URLS_FOR_REGEX)

--- a/postbin/__init__.py
+++ b/postbin/__init__.py
@@ -19,7 +19,6 @@ import asyncio
 
 _FALLBACKS = [
     "https://hastebin.com",
-    "https://mystbin.com",
     "https://paste.pythondiscord.com",
     "https://haste.unbelievaboat.com"
 ]


### PR DESCRIPTION
You fixed the problem in the Sync version but not the Async version.
Basically, you make the request to (assuming it is using hastebin.com) "https://hastebin.com" in Async (will always return 404 error code, as you cannot POST to /), but in Sync you make it to "https://hastebin.com/documents", the correct one to test.